### PR TITLE
LPD-90898 Derive event log entries from current state

### DIFF
--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/ConnectorOverview.tsx
@@ -9,7 +9,7 @@ import ClayList from '@clayui/list';
 import ClaySticker from '@clayui/sticker';
 import ConnectorEntities from './ConnectorEntities';
 import Loading from 'shared/components/Loading';
-import React, {ComponentType, useEffect, useRef, useState} from 'react';
+import React, {ComponentType, useEffect, useState} from 'react';
 import URLConstants from 'shared/util/url-constants';
 import {addAlert} from 'shared/actions/alerts';
 import {Alert} from 'shared/types';
@@ -25,8 +25,7 @@ import {
 import {ConnectorConfig, ConnectorStatus} from './types';
 import {
 	ConnectorStatusItem,
-	getInitialLogEntries,
-	getTransitionEntry
+	getInitialLogEntries
 } from './getConnectorStatusItems';
 import {CopyInputValue} from '../CopyInputValue';
 import {DataSource} from 'shared/util/records';
@@ -479,49 +478,14 @@ const ConnectorEntityList: React.FC<IConnectorEntityListProps> = ({
 
 	const connectorStatus = getConnectorStatus(dataSource);
 
-	const prevCountRef = useRef(totalCount);
-
-	const prevStatusRef = useRef(connectorStatus);
-
-	const seededRef = useRef(false);
-
-	const [logEntries, setLogEntries] = useState<ConnectorStatusItem[]>([]);
-
-	useEffect(() => {
-		if (countResponse.loading) {
-			return;
-		}
-
-		if (!seededRef.current) {
-			seededRef.current = true;
-
-			prevStatusRef.current = connectorStatus;
-			prevCountRef.current = totalCount;
-
-			setLogEntries(getInitialLogEntries(connectorStatus, totalCount));
-
-			return;
-		}
-
-		if (
-			prevStatusRef.current === connectorStatus &&
-			prevCountRef.current === totalCount
-		) {
-			return;
-		}
-
-		prevStatusRef.current = connectorStatus;
-		prevCountRef.current = totalCount;
-
-		setLogEntries(prev => [
-			getTransitionEntry(connectorStatus, totalCount),
-			...prev
-		]);
-	}, [countResponse.loading, connectorStatus, totalCount]);
-
 	if (countResponse.loading) {
 		return <Loading spacer />;
 	}
+
+	const logEntries: ConnectorStatusItem[] = getInitialLogEntries(
+		connectorStatus,
+		totalCount
+	);
 
 	const connectionStatusAlert = getConnectorConnectionStatusAlert(
 		dataSource,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/getConnectorStatusItems.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/__tests__/getConnectorStatusItems.ts
@@ -1,8 +1,5 @@
 import {ConnectorStatus} from '../types';
-import {
-	getInitialLogEntries,
-	getTransitionEntry
-} from '../getConnectorStatusItems';
+import {getInitialLogEntries} from '../getConnectorStatusItems';
 
 describe('getInitialLogEntries', () => {
 	it('seeds a single Token generated entry for Inactive with no data', () => {
@@ -48,44 +45,6 @@ describe('getInitialLogEntries', () => {
 		expect(entries[1].title).toBe('Inactive Data Flow');
 		expect(entries[2].title).toBe('Data Flow Established');
 		expect(entries[3].title).toBe('Listening...');
-	});
-});
-
-describe('getTransitionEntry', () => {
-	it('returns Token generated for Inactive with no data', () => {
-		const entry = getTransitionEntry(ConnectorStatus.Inactive, 0);
-
-		expect(entry.title).toBe('Token Generated');
-		expect(entry.iconDisplayType).toBe('success');
-	});
-
-	it('returns Inactive data flow for Inactive with data', () => {
-		const entry = getTransitionEntry(ConnectorStatus.Inactive, 3);
-
-		expect(entry.title).toBe('Inactive Data Flow');
-		expect(entry.iconDisplayType).toBe('secondary');
-	});
-
-	it('returns Listening for Active with no data', () => {
-		const entry = getTransitionEntry(ConnectorStatus.Active, 0);
-
-		expect(entry.title).toBe('Listening...');
-		expect(entry.iconDisplayType).toBe('success');
-	});
-
-	it('returns Data flow established for Active with data', () => {
-		const entry = getTransitionEntry(ConnectorStatus.Active, 7);
-
-		expect(entry.title).toBe('Data Flow Established');
-		expect(entry.iconDisplayType).toBe('success');
-		expect(entry.bold).toBe(true);
-	});
-
-	it('returns Data source disconnected for Disconnected', () => {
-		const entry = getTransitionEntry(ConnectorStatus.Disconnected, 0);
-
-		expect(entry.title).toBe('Data Source Disconnected');
-		expect(entry.iconDisplayType).toBe('secondary');
 	});
 });
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/getConnectorStatusItems.ts
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/3rd-party-connector/getConnectorStatusItems.ts
@@ -86,18 +86,3 @@ export function getInitialLogEntries(
 
 	return [TOKEN_GENERATED];
 }
-
-export function getTransitionEntry(
-	status: ConnectorStatus,
-	entityCount: number
-): ConnectorStatusItem {
-	if (status === ConnectorStatus.Disconnected) {
-		return DATA_SOURCE_DISCONNECTED;
-	}
-
-	if (status === ConnectorStatus.Active) {
-		return entityCount > 0 ? DATA_FLOW_ACTIVE : LISTENING;
-	}
-
-	return entityCount > 0 ? INACTIVE_DATA_FLOW : TOKEN_GENERATED;
-}


### PR DESCRIPTION
## Summary

- Replace the `useState`/`useEffect`/`useRef` accumulator in `ConnectorEntityList` with a direct derivation: `logEntries = getInitialLogEntries(connectorStatus, totalCount)`.
- Drop the now-unused `getTransitionEntry` helper and its tests.

## Why

`getInitialLogEntries` already encodes the full canonical timeline for any `(status, count)` pair. The accumulator was layering transition entries on top of that canonical timeline, which:

- Is redundant — the count query is one-shot in production (no polling/subscriptions), so during a single render the accumulator never observes more than one state.
- Can produce inconsistent results across transitions. Example: on Disconnect → Reconnect, the helper's canonical for the reconnected state is `[Listening, Token Generated]` (token revoked, fresh start). The accumulator would prepend `Listening` on top of the previous Disconnected history instead — keeping older entries that the helper intentionally omits.

User actions (Disconnect, Generate Token) already trigger `handleUpdateDataSource()`, which re-fetches the data source and causes `ConnectorEntityList` to re-render with the new `dataSource`. Deriving `logEntries` from `(status, count)` on each render produces the right timeline without the extra state machinery.

## Test plan

- `yarn test --testPathPattern='3rd-party-connector'` — 143 tests pass (15 suites).